### PR TITLE
chore: VSCodeの設定を最新化 2024/02 (#DTB-1983)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
 {
 	"name": "Node.js & TypeScript",
-	"image": "mcr.microsoft.com/devcontainers/typescript-node:16-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:20-bullseye",
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		"github-cli": "latest",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		"github-cli": "latest",
-		"fish": "latest"
+		"ghcr.io/meaningful-ooo/devcontainer-features/fish": "latest"
 	},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "editor.formatOnPaste": false,
   "editor.formatOnType": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.format.enable": true,
   "terminal.integrated.defaultProfile.linux": "fish",


### PR DESCRIPTION
- `devcontainer` のnodeのversionを16→20に
- `devcontainer.features` のfishの指定方法を最新化
- `editor.codeActionsOnSave` の設定項目をenumに変更
  - [Visual Studio Code November 2023](https://code.visualstudio.com/updates/v1_85)の変更によるもの